### PR TITLE
refactor: use swaymsg everywhere

### DIFF
--- a/sway-new-workspace
+++ b/sway-new-workspace
@@ -9,7 +9,7 @@ if [[ -n $SR ]]; then
     echo ""
     echo -n "  "
     read newname
-    sway workspace $newname
+    swaymsg workspace $newname
 fi
 
 # launch alacritty instance with the size we want

--- a/sway-rename
+++ b/sway-rename
@@ -9,7 +9,7 @@ if [[ -n $SR ]]; then
     echo ""
     echo -n "  "
     read newname
-    sway rename workspace to $newname
+    swaymsg rename workspace to $newname
 fi
 
 # launch alacritty instance with the size we want


### PR DESCRIPTION
as suggested by @ecocode this pull ensures these scripts use swaymsg
instead of sway.

closes: https://github.com/ldelossa/sway-fzfify/issues/2

Signed-off-by: ldelossa <louis.delos@gmail.com>
