### PR TITLE
dmenu: add exec into fzf string

### DIFF
--- a/sway-dmenu
+++ b/sway-dmenu
@@ -59,11 +59,14 @@ if [[ -n $SMD_FIFO ]]; then
     IFS=$'\n'
     apps=""
     for key in "${!name_to_exec[@]}"; do 
-        apps="$apps\n $key"
+        ex=$(rm_field_codes ${name_to_exec[$key]})
+        ex=${ex##*/}
+        apps="$apps\n $key : $ex"
     done
 
     selection=$(printf $apps | fzf --header=$header --prompt="$prompt" $fzf_color)
     selection=$(echo $selection | xargs echo -n)
+    selection=${selection% :*}
     if [[ -z $selection ]]; then
         exit
     fi


### PR DESCRIPTION
this commit would close #7

adds the `Exec` portion of the .desktop file into the fzf string for
fuzzy selection, then rips it off when looking back into the map for the
exec field.

Signed-off-by: ldelossa <louis.delos@gmail.com>